### PR TITLE
Due to part number change in CMSIS v2.1.0, the JLinkDevices.xml file needs to be updated to reflect the new part numbers

### DIFF
--- a/.alif/JLinkDevices.xml
+++ b/.alif/JLinkDevices.xml
@@ -11,22 +11,7 @@
   <Device>
     <ChipInfo Vendor="AlifSemiconductor" Name="AE302F80F55D5_HP" Aliases="AE302F80F55D5LE_M55_HP; AE302F80F55D5AE_M55_HP" />
   </Device>
-  <Device InheritFrom="AE722F80F55D5_HE">
-    <ChipInfo Name="AE1C1F4051920" Aliases="AE1C1F4051920PH_M55_HE; AE1C1F4051920HH_M55_HE; AE1C1F4051920PH; AE1C1F4051920HH" JLinkScriptFile="1c_reset_override.jlinkscript"/>
-  </Device>
-  <Device InheritFrom="AE722F80F55D5_HE">
-    <ChipInfo Name="AB1C1F4M51820" Aliases="AB1C1F4M51820PH_M55_HE; AB1C1F4M51820HH_M55_HE; AB1C1F4M51820PH; AB1C1F4M51820HH" JLinkScriptFile="1c_reset_override.jlinkscript"/>
-  </Device>
-  <Device InheritFrom="AE722F80F55D5_HE">
-    <ChipInfo Name="AE822FA0E5597LS0_M55_HE" Aliases="AE822FA0E5597BS0_M55_HE" JLinkScriptFile="eagle_warm_rst_unpatch.jlinkscript"/>
-  </Device>
-  <Device InheritFrom="AE722F80F55D5_HP">
-    <ChipInfo Name="AE822FA0E5597LS0_M55_HP" Aliases="AE822FA0E5597BS0_M55_HP" JLinkScriptFile="eagle_warm_rst_unpatch.jlinkscript"/>
-  </Device>
-  <Device InheritFrom="AE722F80F55D5_HE">
-    <ChipInfo Name="AE402FA0E5597LE0_M55_HE" Aliases="AE402FA0E5597BE0_M55_HE" JLinkScriptFile="eagle_warm_rst_unpatch.jlinkscript"/>
-  </Device>
-  <Device InheritFrom="AE722F80F55D5_HP">
-    <ChipInfo Name="AE402FA0E5597LE0_M55_HP" Aliases="AE402FA0E5597BE0_M55_HP" JLinkScriptFile="eagle_warm_rst_unpatch.jlinkscript"/>
+  <Device>
+    <ChipInfo Vendor="AlifSemiconductor" Name="AE1C1F4051920PH" Aliases="AE1C1F4051920PH_M55_HE; AE1C1F4051920PH0_M55_HE" />
   </Device>
 </DataBase>


### PR DESCRIPTION
The part number for E1C was changed in the last commit -- added a zero to the end, and JLink was no longer able to connect. It said there was no matching part number in its database. This is because JLink is still using part numbers without the 0 at the end for E1C.

Tested with the latest JLink package.