### PR TITLE
Require Clangd extension for CMSIS Solution

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
     "recommendations": [
         "arm.environment-manager",
         "arm.cmsis-csolution",
-        "ms-vscode.cpptools-extension-pack",
         "llvm-vs-code-extensions.vscode-clangd",
         "marus25.cortex-debug",
         "arm.vscode-cmsis-debugger"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
         "arm.environment-manager",
         "arm.cmsis-csolution",
         "ms-vscode.cpptools-extension-pack",
+        "llvm-vs-code-extensions.vscode-clangd",
         "marus25.cortex-debug",
         "arm.vscode-cmsis-debugger"
     ]


### PR DESCRIPTION
There are issues with the CMSIS Solution extension when combined with Microsoft's C/C++ Language Pack IntelliSense feature. Starting with versions of CMSIS Solution after v1.60.0, the IntelliSense is not working and we should use Clangd Language Server instead.