### PR TITLE
add non-executable stack flag to linker option

### DIFF
--- a/cdefault.yml
+++ b/cdefault.yml
@@ -7,6 +7,7 @@ default:
         - -fdata-sections
 
       Link:
+        - -z noexecstack
         - --specs=nosys.specs
         - --entry=Reset_Handler
         - -Wl,-Map=linker.map,--cref,-print-memory-usage,--gc-sections,--no-warn-rwx-segments


### PR DESCRIPTION
- It removes the "missing .note.GNU-stack section implies executable stack" warning when building a project